### PR TITLE
Fix: grab_focus() error

### DIFF
--- a/scripts/ui/game_over_menu.gd
+++ b/scripts/ui/game_over_menu.gd
@@ -31,4 +31,5 @@ func _on_quit_to_main_menu_button_pressed() -> void:
 
 
 func _on_visibility_changed() -> void:
-	self.first_element_to_focus.call_deferred("grab_focus")
+	if self.visible:
+		self.first_element_to_focus.call_deferred("grab_focus")


### PR DESCRIPTION
Method was not called when the node is visible